### PR TITLE
Added support for > child selector token

### DIFF
--- a/soupselect.py
+++ b/soupselect.py
@@ -57,7 +57,11 @@ def select(soup, selector):
     """
     tokens = selector.split()
     current_context = [soup]
-    for token in tokens:
+    for index, token in enumerate(tokens):
+        if tokens[index - 1] == '>':
+            # already found direct descendants in last step
+            continue
+
         m = attribselect_re.match(token)
         if m:
             # Attribute selector
@@ -70,6 +74,7 @@ def select(soup, selector):
                 found.extend([el for el in context.findAll(tag) if checker(el)])
             current_context = found
             continue
+
         if '#' in token:
             # ID selector
             tag, id = token.split('#', 1)
@@ -80,6 +85,7 @@ def select(soup, selector):
                 return [] # No match
             current_context = [el]
             continue
+
         if '.' in token:
             # Class selector
             tag, klass = token.split('.', 1)
@@ -96,6 +102,7 @@ def select(soup, selector):
                 )
             current_context = found
             continue
+
         if token == '*':
             # Star selector
             found = []
@@ -103,6 +110,19 @@ def select(soup, selector):
                 found.extend(context.findAll(True))
             current_context = found
             continue
+
+        if token == '>':
+            # Child selector
+            tag = tokens[index + 1]
+            if not tag:
+                tag = True
+
+            found = []
+            for context in current_context:
+                found.extend(context.findAll(tag, recursive=False))
+            current_context = found
+            continue
+
         # Here we should just have a regular tag
         if not tag_re.match(token):
             return []

--- a/soupselect_tests.py
+++ b/soupselect_tests.py
@@ -31,24 +31,24 @@ class TestBasicSelectors(BaseTest):
         self.assertEqual(len(els), 1)
         self.assertEqual(els[0].name, 'title')
         self.assertEqual(els[0].contents, [u'The title'])
-    
+
     def test_one_tag_many(self):
         els = select(self.soup, 'div')
         self.assertEqual(len(els), 3)
         for div in els:
             self.assertEqual(div.name, 'div')
-    
+
     def test_tag_in_tag_one(self):
         els = select(self.soup, 'div div')
         self.assertSelects('div div', ['inner'])
-    
+
     def test_tag_in_tag_many(self):
         for selector in ('html div', 'html body div', 'body div'):
             self.assertSelects(selector, ['main', 'inner', 'footer'])
-    
+
     def test_tag_no_match(self):
         self.assertEqual(len(select(self.soup, 'del')), 0)
-    
+
     def test_invalid_tag(self):
         self.assertEqual(len(select(self.soup, 'tag%t')), 0)
 
@@ -64,7 +64,7 @@ class TestBasicSelectors(BaseTest):
             self.assertEqual(len(els), 1)
             self.assertEqual(els[0].name, 'p')
             self.assertEqual(els[0]['class'], 'onep')
-        
+
     def test_class_mismatched_tag(self):
         els = select(self.soup, 'div.onep')
         self.assertEqual(len(els), 0)
@@ -72,7 +72,7 @@ class TestBasicSelectors(BaseTest):
     def test_one_id(self):
         for selector in ('div#inner', '#inner', 'div div#inner'):
             self.assertSelects(selector, ['inner'])
-    
+
     def test_bad_id(self):
         els = select(self.soup, '#doesnotexist')
         self.assertEqual(len(els), 0)
@@ -98,6 +98,11 @@ class TestBasicSelectors(BaseTest):
         for selector in ('.class1.class3', '.class3.class2',
                          '.class1.class2.class3'):
             self.assertSelects(selector, ['pmulti'])
+
+    def test_child_selector(self):
+        self.assertSelects('.s1 > a', ['s1a1', 's1a2'])
+        self.assertSelects('.s1 > a span', ['s1a2s1'])
+
 
 class TestAttributeSelectors(BaseTest):
 
@@ -154,7 +159,7 @@ class TestAttributeSelectors(BaseTest):
             ('[href$=".css"]', ['l1']),
             ('link[href$=".css"]', ['l1']),
             ('link[id$="1"]', ['l1']),
-            ('[id$="1"]', ['l1', 'p1', 'header1']),
+            ('[id$="1"]', ['l1', 'p1', 'header1', 's1a1', 's2a1', 's1a2s1']),
             ('div[id$="1"]', []),
             ('[id$="noending"]', []),
         )
@@ -177,7 +182,7 @@ class TestAttributeSelectors(BaseTest):
             ('[href*=".css"]', ['l1']),
             ('link[href*=".css"]', ['l1']),
             ('link[id*="1"]', ['l1']),
-            ('[id*="1"]', ['l1', 'p1', 'header1']),
+            ('[id*="1"]', ['l1', 'p1', 'header1', 's1a1', 's1a2', 's2a1', 's1a2s1']),
             ('div[id*="1"]', []),
             ('[id*="noending"]', []),
             # New for this test
@@ -275,6 +280,14 @@ HTML = """
         <a href="http://bob.example.org/" rel="friend met" id="bob">Bob</a>
         <h2 id="header3">Another H2</h2>
         <a id="me" href="http://simonwillison.net/" rel="me">me</a>
+        <span class="s1">
+            <a href="#" id="s1a1">span1a1</a>
+            <a href="#" id="s1a2">span1a2 <span id="s1a2s1">test</span></a>
+            <span class="span2">
+                <a href="#" id="s2a1">span2a1</a>
+            </span>
+            <span class="span3"></span>
+        </span>
     </div>
     <p lang="en" id="lang-en">English</p>
     <p lang="en-gb" id="lang-en-gb">English UK</p>


### PR DESCRIPTION
The `>` adds support for selecting the immediate children of a parent.
